### PR TITLE
ran npm audit fix so we good now i think

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4803,9 +4803,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "requires": {
         "eslint-visitor-keys": "^1.0.0"
       }


### PR DESCRIPTION
## Summary

Uh oh...

GHSA-3gx7-xhv7-5mx3 More information
critical severity
Vulnerable versions: >= 1.2.0, < 1.4.1
Patched version: 1.4.1
'getStaticValue' function can execute arbitrary code
Impact
getStaticValue function can execute arbitrary code.

Patches
This problem has been patched in 1.4.1. Please update eslint-utils.

Workarounds
Don't use getStaticValue function, getStringIfConstant function, and getPropertyName function.